### PR TITLE
Add qr code to response xsd

### DIFF
--- a/lib/my_data/xsd/docs/response-v1.0.2.xsd
+++ b/lib/my_data/xsd/docs/response-v1.0.2.xsd
@@ -44,6 +44,11 @@
 							<xs:documentation>Συμβολοσειρά Αυθεντικοποίησης Παρόχου</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="qrUrl" type="xs:string" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>QR Code Url</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 				</xs:sequence>
 				<xs:element name="errors">
 					<xs:annotation>

--- a/spec/cassettes/send_invoices_success_modified_v1_0_7.yml
+++ b/spec/cassettes/send_invoices_success_modified_v1_0_7.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://mydataapidev.aade.gr/SendInvoices
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <InvoicesDoc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.aade.gr/myDATA/invoice/v1.0" xmlns:schema="http://www.aade.gr/myDATA/invoice/v1.0 schemaLocation.xsd" xmlns:inv="http://www.aade.gr/myDATA/invoice/v1.0" xmlns:icls="https://www.aade.gr/myDATA/incomeClassificaton/v1.0" xmlns:ecls="https://www.aade.gr/myDATA/expensesClassificaton/v1.0">
+          <invoice>
+            <issuer>
+              <vatNumber>111111111</vatNumber>
+              <country>GR</country>
+              <branch>0</branch>
+            </issuer>
+            <invoiceHeader>
+              <series>A</series>
+              <aa>1</aa>
+              <issueDate>2021-02-21</issueDate>
+              <invoiceType>11.2</invoiceType>
+              <currency>EUR</currency>
+            </invoiceHeader>
+            <paymentMethods>
+              <paymentMethodDetails>
+                <type>3</type>
+                <amount>124.0</amount>
+              </paymentMethodDetails>
+            </paymentMethods>
+            <invoiceDetails>
+              <lineNumber>1</lineNumber>
+              <netValue>100.0</netValue>
+              <vatCategory>1</vatCategory>
+              <vatAmount>24.0</vatAmount>
+              <incomeClassification>
+                <icls:classificationType>E3_561_003</icls:classificationType>
+                <icls:classificationCategory>category1_3</icls:classificationCategory>
+                <icls:amount>100.0</icls:amount>
+              </incomeClassification>
+            </invoiceDetails>
+            <invoiceSummary>
+              <totalNetValue>100.0</totalNetValue>
+              <totalVatAmount>24.0</totalVatAmount>
+              <totalWithheldAmount>0.0</totalWithheldAmount>
+              <totalFeesAmount>0.0</totalFeesAmount>
+              <totalStampDutyAmount>0.0</totalStampDutyAmount>
+              <totalOtherTaxesAmount>0.0</totalOtherTaxesAmount>
+              <totalDeductionsAmount>0.0</totalDeductionsAmount>
+              <totalGrossValue>124.0</totalGrossValue>
+              <incomeClassification>
+                <icls:classificationType>E3_561_003</icls:classificationType>
+                <icls:classificationCategory>category1_3</icls:classificationCategory>
+                <icls:amount>100.0</icls:amount>
+              </incomeClassification>
+            </invoiceSummary>
+          </invoice>
+        </InvoicesDoc>
+    headers:
+      Content-Type:
+        - application/xml
+      Accept:
+        - application/xml
+      Aade-User-Id:
+        - johndoe
+      Ocp-Apim-Subscription-Key:
+        - c9b79ff1841fb5cfecc66e1ea5a29b4d
+      User-Agent:
+        - Faraday v1.3.0
+      Accept-Encoding:
+        - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+        - Tue, 05 Dec 2023 17:31:28 GMT
+      Content-Type:
+        - application/xml; charset=utf-8
+      Content-Length:
+        - '728'
+      Connection:
+        - keep-alive
+      Request-Context:
+        - appId=cid-v1:13c4bd32-05a8-456a-a0a3-25e8a821dcf9
+    body:
+      encoding: UTF-8
+      string: "<string xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/\">&lt;?xml
+      version=\"1.0\" encoding=\"utf-8\"?&gt;\r\n&lt;ResponseDoc xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
+      xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"&gt;\r\n  &lt;response&gt;\r\n
+      \   &lt;index&gt;1&lt;/index&gt;\r\n    &lt;invoiceUid&gt;4626E9F44FAC8F6BB3B8BBF36EF21377E8202407&lt;/invoiceUid&gt;\r\n
+      \   &lt;invoiceMark&gt;400001832005979&lt;/invoiceMark&gt;\r\n    &lt;qrUrl&gt;https://mydataapidev.aade.gr/TimologioQR/QRInfo?q=encoded_string_replaced_on_cassette&lt;/qrUrl&gt;\r\n
+      \   &lt;statusCode&gt;Success&lt;/statusCode&gt;\r\n  &lt;/response&gt;\r\n&lt;/ResponseDoc&gt;</string>"
+  recorded_at: Tue, 05 Dec 2023 17:31:28 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/my_data/client_spec.rb
+++ b/spec/lib/my_data/client_spec.rb
@@ -158,6 +158,14 @@ RSpec.describe MyData::Client do
         expect(response_parser.errors).to be_empty
       end
     end
+
+    context "when request is successful (myDATA API 1.0.7)", vcr: { cassette_name: "send_invoices_success_modified_v1_0_7", match_requests_on: [:body] } do
+      let(:doc) { build(:invoices_doc).to_xml }
+
+      it "has proper qr_url" do
+        expect(response_parser.response.response.first.qr_url).to eq("https://mydataapidev.aade.gr/TimologioQR/QRInfo?q=encoded_string_replaced_on_cassette")
+      end
+    end
   end
 
   describe "#cancel_invoice" do


### PR DESCRIPTION
## add qrUrl to SendInvoices response

Starting 2024, it will be required to display QR codes on invoices that have been sent to myDATA.

To accommodate that requirement a new field "qrUrl" has been added to the response type, as per [myDATA API 1.0.7 ERP documentation](https://www.aade.gr/sites/default/files/2023-10/myDATA%20API%20Documentation%20v1.0.7_official_erp.pdf) in page 43.

The latest official **response-v1.0.7.xsd** from the [updated xsd files](https://www.aade.gr/sites/default/files/2023-10/version%20v1.0.7%20XSDs%20.7z) does not seem to contain that element as of the time of this writing.

Would it be an acceptable solution to add this element directly to the current response-v1.0.2.xsd file and let **MyData::ResponseParser** with resource: **MyData::Resources::Response** handle the parsing of the new element?